### PR TITLE
Remove fuse-gulp-rollup-babel

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,6 @@ Like `awesome-fuse`? Reach out to me and say *hi* on [Twitter](https://twitter.c
 - [Fuse Tags with Firebase](https://github.com/LuisRodriguezLD/Fuse-Tags-with-Firebase) - Simple Tags app. Adds and retrieves tags from Firebase.
 - [FuseBus](http://tmn.github.io/FuseBus/) - A simple Fuse application for testing and funtimes.
 - [Gulp Procedure](https://github.com/joms/gulp-fuse) - Gulp-procedure for Fuse compiling ES6 into ES5.
-- [Gulp Rollup Babel](https://github.com/sebbert/fuse-gulp-rollup-babel) - An alternative example of module bundling and ES6 -> ES5 transpiling.
 - [Haxe](https://github.com/elsassph/fusetools-haxe) - Haxe compiler for Fuse tools.
 - [Hikr](https://github.com/fusetools/hikr) - An example app case to accompany [Fuse's end-to-end tutorial](https://www.fusetools.com/docs/tutorial/tutorial).
 - [Infinite Scroll](https://bitbucket.org/uzeidurs/fuse-infinite-scroll/) - An example implementation of "infinite scroll" for use with Fuse Tools version 0.26 and above.


### PR DESCRIPTION
Fuse has had support for `require()` for a good while now. Thus, module bundling is no longer needed and should be considered an obsolete hack.

See [this forum post](https://www.fusetools.com/community/forums/howto_discussions/es6_router_parameter?page=1&highlight=a7920bf1-c9f7-48f6-931f-f624ab0f5919#post-a7920bf1-c9f7-48f6-931f-f624ab0f5919) for more info